### PR TITLE
add Android back button functionality

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -78,6 +78,13 @@ const WithDecorator = WebViewDecorator(WebView);
 export default createWebViewNavigator(WithDecorator, routesConfig, webviewConfig);
 ```
 
+If you want to enhance the WebView with Android's back button behaviour, pass React Native's BackHandler to it:
+
+```
+import { WebView, BackHandler } from 'react-native';
+...
+const WithDecorator = WebViewDecorator(WebView, BackHandler);
+```
 
 ## React Navigation Useful Docs
 

--- a/README.MD
+++ b/README.MD
@@ -25,7 +25,7 @@ createWebViewNavigator function will create a StackRouter to keep track of uri r
 ```
 import React from 'react';
 import { View, Text } from 'react-native';
-import { createWebViewNavigator } from 'react-navigation';
+import { createWebViewNavigator } from 'react-navigation-webview';
 
 class UriView extends React.Component {
   render() {

--- a/src/WebViewDecorator.js
+++ b/src/WebViewDecorator.js
@@ -1,21 +1,95 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import asQuery from 'jquery-param';
+import React from "react";
+import PropTypes from "prop-types";
+import asQuery from "jquery-param";
 
-const withWebViewDecorator = (WebView) => {
-  const WebViewDecorator = ({ uri, navigation, ...navProps }) => {
-    const params = navigation.getParam('query') || undefined;
-    const url = params ? `${uri}?${asQuery(params)}` : uri;
-    const props = { ...navProps, navigation, source: { uri: url } };
-    return (
-      <WebView {...props} />
-    );
-  };
+const withWebViewDecorator = (WebView, BackHandler = null) => {
+  class WebViewDecorator extends React.Component {
+    _didFocusSubscription;
+    _willBlurSubscription;
+    _hasFocusSubscription;
+
+    state = {
+      canGoBack: false
+    };
+
+    constructor(props) {
+      super(props);
+      if (BackHandler) {
+        // this can fire before component has mounted ...
+        this._didFocusSubscription = this.props.navigation.addListener(
+          "didFocus",
+          // ...so this call also goes into componentDidMount
+          payload => this.addBackButtonListener()
+        );
+      }
+    }
+
+    componentDidMount() {
+      if (BackHandler) {
+        this.addBackButtonListener();
+        this._willBlurSubscription = this.props.navigation.addListener(
+          "willBlur",
+          payload =>
+            BackHandler.removeEventListener(
+              "hardwareBackPress",
+              this.onBackButtonPressAndroid
+            )
+        );
+      }
+    }
+
+    addBackButtonListener() {
+      // guard against adding this twice
+      if (!this.hasFocusSubscription) {
+        this.hasFocusSubscription = true;
+        BackHandler.addEventListener(
+          "hardwareBackPress",
+          this.onBackButtonPressAndroid
+        );
+      }
+    }
+
+    onNavigationStateChange(navState) {
+      if (BackHandler) {
+        this.setState({
+          canGoBack: navState.canGoBack
+        });
+      }
+    }
+
+    onBackButtonPressAndroid = () => {
+      if (this.state.canGoBack) {
+        this.webViewRef.goBack();
+        return true;
+      }
+      return false;
+    };
+
+    componentWillUnmount() {
+      this._didFocusSubscription && this._didFocusSubscription.remove();
+      this._willBlurSubscription && this._willBlurSubscription.remove();
+    }
+
+    render() {
+      const { uri, navigation, ...navProps } = this.props;
+      const params = navigation.getParam("query") || undefined;
+      const url = params ? `${uri}?${asQuery(params)}` : uri;
+      const props = { ...navProps, navigation, source: { uri: url } };
+      return (
+        <WebView
+          onNavigationStateChange={this.onNavigationStateChange.bind(this)}
+          ref={ref => (this.webViewRef = ref)}
+          {...props}
+        />
+      );
+    }
+  }
+
   WebViewDecorator.propTypes = {
     uri: PropTypes.string.isRequired,
     navigation: PropTypes.shape({
-      getParam: PropTypes.func.isRequired,
-    }).isRequired,
+      getParam: PropTypes.func.isRequired
+    }).isRequired
   };
   return WebViewDecorator;
 };


### PR DESCRIPTION
Most of the time, a user expects to be taken back to the previous page in the `WebView` when they use the Android back button. So I've included the option to bass the `BackHandler` to the `WebViewDecorator` if they want this to happen.

Resources:
https://reactnavigation.org/docs/en/custom-android-back-button-handling.html
https://blog.defining.tech/adding-a-back-button-for-react-native-webview-4a6fa9cd0b0